### PR TITLE
Fix overlapping CPP keywords

### DIFF
--- a/scss/_sphinx_base.scss
+++ b/scss/_sphinx_base.scss
@@ -449,9 +449,8 @@ article.pytorch-article {
     dt {
       border-left: none;
       border-top: 3px solid $red_orange;
-      padding-left: 4em;
+      padding-left: 0.5em;
       em.property {
-        position: absolute;
         left: 0.5rem;
       }
     }


### PR DESCRIPTION
This commit fixes overlapping keywords in the CPP Docs

Before: 
<img width="728" alt="Screen Shot 2020-02-26 at 2 42 30 PM" src="https://user-images.githubusercontent.com/31549535/75381204-57424e00-58a6-11ea-9509-94959006ac6d.png">


After:
<img width="838" alt="Screen Shot 2020-02-26 at 2 44 54 PM" src="https://user-images.githubusercontent.com/31549535/75381343-96709f00-58a6-11ea-9b9d-9e7a67fc8ab5.png">

