### PR TITLE
Jump to filter tags on click of next card page

### DIFF
--- a/js/theme.js
+++ b/js/theme.js
@@ -343,3 +343,12 @@ $("#tutorial-cards p").each(function(index, item) {
         $(item).remove();
     }
 });
+
+// Jump back to top on pagination click
+
+$(document).on("click", ".page", function() {
+    $('html, body').animate(
+      {scrollTop: $("#dropdown-filter-tags").position().top},
+      'slow'
+    );
+});


### PR DESCRIPTION
This PR adds functionality to solve issue where page would jump to footer
when clicking on a page with less than the full amount of cards