### PR TITLE
Update code font

### DIFF
--- a/pytorch_sphinx_theme/static/css/theme.css
+++ b/pytorch_sphinx_theme/static/css/theme.css
@@ -10521,9 +10521,9 @@ article.pytorch-article .sphx-glr-thumbcontainer .figure a.reference.internal {
 
 article.pytorch-article .section :not(dt) > code {
   color: #262626;
-  border-top: solid 2px #f3f4f7;
-  background-color: #f3f4f7;
-  border-bottom: solid 2px #f3f4f7;
+  border-top: solid 2px #ffffff;
+  background-color: #ffffff;
+  border-bottom: solid 2px #ffffff;
   padding: 0px 3px;
   -webkit-box-decoration-break: clone;
   box-decoration-break: clone;
@@ -11002,7 +11002,6 @@ article.pytorch-article .wy-table-responsive table tbody td {
 }
 article.pytorch-article .wy-table-responsive table tbody td .pre {
   background: #ffffff;
-  outline: 1px solid #e9e9e9;
   color: #ee4c2c;
   font-size: 87.5%;
 }

--- a/scss/_sphinx_base.scss
+++ b/scss/_sphinx_base.scss
@@ -336,7 +336,7 @@ article.pytorch-article {
   .section {
     :not(dt) > code {
       color: $not_quite_black;
-      @include format-code($light_grey);
+      @include format-code($white);
     }
   }
 
@@ -723,7 +723,6 @@ article.pytorch-article {
           line-height: rem(22px);
           .pre {
             background: $white;
-            outline: 1px solid #e9e9e9;
             color: $red_orange;
             font-size: 87.5%;
           }


### PR DESCRIPTION
This PR fixes the code font space issue seen in this table: https://pytorch.org/docs/master/jit_language_reference.html#supported-type.

<img width="914" alt="Screen Shot 2020-10-20 at 9 23 01 AM" src="https://user-images.githubusercontent.com/16585245/96591993-e4169d80-12b5-11eb-9709-598f9b26d118.png">

Preview: https://5f8edec4059f280093861c01--shiftlab-pytorch-docs.netlify.app/jit_language_reference.html#supported-type