### PR TITLE
Add minimum height to article sections

### DIFF
--- a/scss/_sphinx_base.scss
+++ b/scss/_sphinx_base.scss
@@ -339,6 +339,9 @@ article.pytorch-article {
       @include format-code($light_grey);
     }
   }
+  .section:only-of-type {
+    min-height: 70vh;
+  }
 
   .function {
     dt {

--- a/scss/_sphinx_layout.scss
+++ b/scss/_sphinx_layout.scss
@@ -45,6 +45,7 @@
 }
 
 .pytorch-content-left {
+  min-height: 100vh;
   margin-top: rem(40px);
   width: 100%;
 


### PR DESCRIPTION
This PR adds a minimum height to articles that only have 1 section

Preview: https://5fadafbc0a2d43ba09160781--shiftlab-pytorch-docs.netlify.app/

_Note:_ https://5fadafbc0a2d43ba09160781--shiftlab-pytorch-docs.netlify.app/ffi.html is a page where there is only one article and the change is present. 