### PR TITLE
Wrap Tutorials/Gallery divs

### DIFF
--- a/js/theme.js
+++ b/js/theme.js
@@ -307,12 +307,6 @@ $(document).ready(function() {
   }
 });
 
-// Get the card link from the card's link attribute
-
-$(".tutorials-card").on("click", function() {
-    window.location = $(this).attr("link");
-});
-
 // Build an array from each tag that's present
 
 var tagList = $(".tutorials-card-container").map(function() {

--- a/pytorch_sphinx_theme/static/js/theme.js
+++ b/pytorch_sphinx_theme/static/js/theme.js
@@ -1002,12 +1002,6 @@ $(document).ready(function() {
   }
 });
 
-// Get the card link from the card's link attribute
-
-$(".tutorials-card").on("click", function() {
-    window.location = $(this).attr("link");
-});
-
 // Build an array from each tag that's present
 
 var tagList = $(".tutorials-card-container").map(function() {


### PR DESCRIPTION
This PR removes JS responsible for Tutorial cards on click behavior. This JS overrides the default "open in new tab" behavior. 

**This PR is related to [#6](https://github.com/shiftlab/tutorials/pull/6) and helps solve this [issue](https://github.com/pytorch/pytorch_sphinx_theme/issues/93).**